### PR TITLE
Rewrite login logic

### DIFF
--- a/apps/auth/controllers/sessions/create.rb
+++ b/apps/auth/controllers/sessions/create.rb
@@ -13,6 +13,8 @@ module Auth::Controllers::Sessions
       unless user = account.user
         user = user_repo.find_by_login(user_params[:login]) || user_repo.create(user_params)
         account_repo.update(account.id, user_id: user.id)
+
+        account = account_repo.find(account.id)
       end
 
       session[:account] = account

--- a/apps/auth/controllers/sessions/create.rb
+++ b/apps/auth/controllers/sessions/create.rb
@@ -8,7 +8,11 @@ module Auth::Controllers::Sessions
         redirect_to '/'
       end
 
-      session[:current_user] = repo.find_by_uuid(omniauth_params['uid']) || repo.create(user_params)
+      user = user_repo.find_by_uuid(omniauth_params['uid']) || user_repo.create(user_params)
+
+      session[:account] = AccountRepository.new.create(account_params(user))
+      session[:current_user] = user
+
       redirect_to session[:current_path] || '/'
     end
 
@@ -18,8 +22,8 @@ module Auth::Controllers::Sessions
       BlokedUserRepository.new.exist?(omniauth_params['extra']['raw_info']['login'])
     end
 
-    def repo
-      @repo ||= UserRepository.new
+    def user_repo
+      @user_repo ||= UserRepository.new
     end
 
     def omniauth_params
@@ -34,6 +38,14 @@ module Auth::Controllers::Sessions
       params[:name] = omniauth_params['extra']['raw_info']['name']
       params[:email] = omniauth_params['extra']['raw_info']['email']
       params[:bio] = omniauth_params['extra']['raw_info']['bio']
+      params
+    end
+
+    def account_params(user)
+      params = {}
+      params[:uid]   = omniauth_params['uid']
+      params[:token] = omniauth_params['credentials']['token']
+      params[:user_id] = user.id
       params
     end
   end

--- a/apps/auth/controllers/sessions/create.rb
+++ b/apps/auth/controllers/sessions/create.rb
@@ -11,8 +11,8 @@ module Auth::Controllers::Sessions
       account = account_repo.find_by_uid(omniauth_params['uid']) || account_repo.create(account_params)
 
       unless account.user
-        account_repo.update(account.id, user_id: finded_user_by_login.id)
-        account = account_repo.find(account.id)
+        account_repo.update(account.id, user_id: user.id)
+        account.user = user
       end
 
       set_session(account)
@@ -26,8 +26,8 @@ module Auth::Controllers::Sessions
       session[:current_user] = account.user
     end
 
-    def finded_user_by_login
-      @finded_user_by_login ||= user_repo.find_by_login(user_params[:login]) || user_repo.create(user_params)
+    def user
+      @user ||= user_repo.find_by_login(user_params[:login]) || user_repo.create(user_params)
     end
 
     def user_bloked?(omniauth_params)

--- a/apps/auth/controllers/sessions/create.rb
+++ b/apps/auth/controllers/sessions/create.rb
@@ -3,7 +3,7 @@ module Auth::Controllers::Sessions
     include Auth::Action
 
     def call(params)
-      if user_bloked?(omniauth_params)
+      if user_bloked?
         flash[:error] = 'Sorry, but you was blocked. Please contact with maintainer'
         redirect_to '/'
       end
@@ -30,8 +30,8 @@ module Auth::Controllers::Sessions
       @user ||= user_repo.find_by_login(user_params[:login]) || user_repo.create(user_params)
     end
 
-    def user_bloked?(omniauth_params)
-      BlokedUserRepository.new.exist?(omniauth_params['extra']['raw_info']['login'])
+    def user_bloked?
+      BlokedUserRepository.new.exist?(user_params[:login])
     end
 
     def user_repo
@@ -47,21 +47,21 @@ module Auth::Controllers::Sessions
     end
 
     def user_params
-      params = {}
-      params[:uuid] = omniauth_params['uid']
-      params[:login] = omniauth_params['extra']['raw_info']['login']
-      params[:avatar_url] = omniauth_params['extra']['raw_info']['avatar_url']
-      params[:name] = omniauth_params['extra']['raw_info']['name']
-      params[:email] = omniauth_params['extra']['raw_info']['email']
-      params[:bio] = omniauth_params['extra']['raw_info']['bio']
-      params
+      @user_params ||= {
+        uuid: omniauth_params['uid'],
+        login: omniauth_params['extra']['raw_info']['login'],
+        avatar_url: omniauth_params['extra']['raw_info']['avatar_url'],
+        name: omniauth_params['extra']['raw_info']['name'],
+        email: omniauth_params['extra']['raw_info']['email'],
+        bio: omniauth_params['extra']['raw_info']['bio']
+      }
     end
 
     def account_params
-      params = {}
-      params[:uid]   = omniauth_params['uid']
-      params[:token] = omniauth_params['credentials']['token']
-      params
+      @account_params ||= {
+        uid: omniauth_params['uid'],
+        token: omniauth_params['credentials']['token']
+      }
     end
   end
 end

--- a/apps/auth/controllers/sessions/create.rb
+++ b/apps/auth/controllers/sessions/create.rb
@@ -10,20 +10,25 @@ module Auth::Controllers::Sessions
 
       account = account_repo.find_by_uid(omniauth_params['uid']) || account_repo.create(account_params)
 
-      unless user = account.user
-        user = user_repo.find_by_login(user_params[:login]) || user_repo.create(user_params)
-        account_repo.update(account.id, user_id: user.id)
-
+      unless account.user
+        account_repo.update(account.id, user_id: finded_user_by_login.id)
         account = account_repo.find(account.id)
       end
 
-      session[:account] = account
-      session[:current_user] = user
-
+      set_session(account)
       redirect_to session[:current_path] || '/'
     end
 
     private
+
+    def set_session(account)
+      session[:account] = account
+      session[:current_user] = account.user
+    end
+
+    def finded_user_by_login
+      @finded_user_by_login ||= user_repo.find_by_login(user_params[:login]) || user_repo.create(user_params)
+    end
 
     def user_bloked?(omniauth_params)
       BlokedUserRepository.new.exist?(omniauth_params['extra']['raw_info']['login'])

--- a/apps/auth/controllers/sessions/destroy.rb
+++ b/apps/auth/controllers/sessions/destroy.rb
@@ -4,6 +4,7 @@ module Auth::Controllers::Sessions
 
     def call(params)
       session[:current_user] = nil
+      session[:account] = nil
       redirect_to session[:current_path] || '/'
     end
   end

--- a/db/migrations/20170202000525_create_accounts.rb
+++ b/db/migrations/20170202000525_create_accounts.rb
@@ -2,7 +2,7 @@ Hanami::Model.migration do
   change do
     create_table :accounts do
       primary_key :id
-      foreign_key :user_id, :users, null: false
+      foreign_key :user_id, :users, on_delete: :cascade
 
       column :uid,                 String
       column :token,               String

--- a/db/migrations/20170202000525_create_accounts.rb
+++ b/db/migrations/20170202000525_create_accounts.rb
@@ -1,0 +1,12 @@
+Hanami::Model.migration do
+  change do
+    create_table :accounts do
+      primary_key :id
+      foreign_key :user_id, :users, null: false
+
+      column :uid,                 String
+      column :token,               String
+      column :extended_privileges, TrueClass, default: false
+    end
+  end
+end

--- a/db/migrations/20170202232734_drop_uuid_form_users.rb
+++ b/db/migrations/20170202232734_drop_uuid_form_users.rb
@@ -1,0 +1,7 @@
+Hanami::Model.migration do
+  change do
+    alter_table :users do
+      drop_column :uuid
+    end
+  end
+end

--- a/lib/authentication.rb
+++ b/lib/authentication.rb
@@ -2,6 +2,7 @@ module Authentication
   def self.included(action)
     action.class_eval do
       expose :current_user
+      expose :account
     end
   end
 
@@ -12,10 +13,14 @@ private
   end
 
   def authenticated?
-    current_user.registred?
+    current_user.registred? || account.registred?
   end
 
   def current_user
     @current_user ||= session[:current_user] || User.new
+  end
+
+  def account
+    @account ||= session[:account] || Account.new
   end
 end

--- a/lib/ossboard/entities/account.rb
+++ b/lib/ossboard/entities/account.rb
@@ -1,0 +1,2 @@
+class Account < Hanami::Entity
+end

--- a/lib/ossboard/entities/account.rb
+++ b/lib/ossboard/entities/account.rb
@@ -1,4 +1,8 @@
 class Account < Hanami::Entity
+  def registred?
+    !!id
+  end
+
   # TODO: Tests
   def user
     UserRepository.new.find(user_id)

--- a/lib/ossboard/entities/account.rb
+++ b/lib/ossboard/entities/account.rb
@@ -1,2 +1,6 @@
 class Account < Hanami::Entity
+  # TODO: Tests
+  def user
+    UserRepository.new.find(user_id)
+  end
 end

--- a/lib/ossboard/entities/account.rb
+++ b/lib/ossboard/entities/account.rb
@@ -1,9 +1,10 @@
 class Account < Hanami::Entity
+  attr_reader :attributes
+
   def registred?
     !!id
   end
 
-  # TODO: Tests
   def user=(user)
     attributes[:user] = user
   end
@@ -11,8 +12,4 @@ class Account < Hanami::Entity
   def user
     attributes[:user] || UserRepository.new.find(user_id)
   end
-
-private
-
-  attr_reader :attributes
 end

--- a/lib/ossboard/entities/account.rb
+++ b/lib/ossboard/entities/account.rb
@@ -4,7 +4,15 @@ class Account < Hanami::Entity
   end
 
   # TODO: Tests
-  def user
-    UserRepository.new.find(user_id)
+  def user=(user)
+    attributes[:user] = user
   end
+
+  def user
+    attributes[:user] || UserRepository.new.find(user_id)
+  end
+
+private
+
+  attr_reader :attributes
 end

--- a/lib/ossboard/repositories/account_repository.rb
+++ b/lib/ossboard/repositories/account_repository.rb
@@ -1,0 +1,2 @@
+class AccountRepository < Hanami::Repository
+end

--- a/lib/ossboard/repositories/account_repository.rb
+++ b/lib/ossboard/repositories/account_repository.rb
@@ -2,4 +2,8 @@ class AccountRepository < Hanami::Repository
   associations do
     belongs_to :user
   end
+
+  def find_by_uid(uid)
+    accounts.where(uid: uid).as(Account).first
+  end
 end

--- a/lib/ossboard/repositories/account_repository.rb
+++ b/lib/ossboard/repositories/account_repository.rb
@@ -1,2 +1,5 @@
 class AccountRepository < Hanami::Repository
+  associations do
+    belongs_to :user
+  end
 end

--- a/lib/ossboard/repositories/user_repository.rb
+++ b/lib/ossboard/repositories/user_repository.rb
@@ -1,6 +1,7 @@
 class UserRepository < Hanami::Repository
   associations do
     has_many :tasks
+    has_many :accounts
   end
 
   def admins

--- a/lib/ossboard/repositories/user_repository.rb
+++ b/lib/ossboard/repositories/user_repository.rb
@@ -30,10 +30,6 @@ class UserRepository < Hanami::Repository
     aggregate(:tasks).where(login: login).as(User).first
   end
 
-  def find_by_uuid(uuid)
-    users.where(uuid: uuid).as(User).first
-  end
-
   def find_with_tasks(id)
     aggregate(:tasks).where(id: id).as(User).one
   end

--- a/spec/auth/controllers/sessions/create_spec.rb
+++ b/spec/auth/controllers/sessions/create_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe Auth::Controllers::Sessions::Create do
       expect(action.session[:current_user].name).to eq "Anton Davydov"
       expect(action.session[:current_user].email).to eq "mail@davydovanton.com"
       expect(action.session[:current_user].bio).to eq "Indie OSS developer"
-      expect(action.session[:current_user].uuid).to eq uuid
 
       expect(action.session[:account]).to be_a Account
       expect(action.session[:account].uid).to eq uuid
@@ -92,7 +91,7 @@ RSpec.describe Auth::Controllers::Sessions::Create do
   context 'when user and account exist' do
     before do
       user = Fabricate.create(:user,
-        uuid: uuid, login: "davydovanton", avatar_url: "https://avatars.githubusercontent.com/u/1147484?v=3",
+        login: "davydovanton", avatar_url: "https://avatars.githubusercontent.com/u/1147484?v=3",
         name: "Anton Davydov", email: "mail@davydovanton.com", bio: "Indie OSS developer")
       account_repo.create(user_id: user.id, uid: uuid)
     end
@@ -113,7 +112,6 @@ RSpec.describe Auth::Controllers::Sessions::Create do
       expect(action.session[:current_user].name).to eq "Anton Davydov"
       expect(action.session[:current_user].email).to eq "mail@davydovanton.com"
       expect(action.session[:current_user].bio).to eq "Indie OSS developer"
-      expect(action.session[:current_user].uuid).to eq uuid
 
       expect(action.session[:account]).to be_a Account
       expect(action.session[:account].uid).to eq uuid
@@ -123,7 +121,7 @@ RSpec.describe Auth::Controllers::Sessions::Create do
   context 'when user exist and account does not exist' do
     before do
       @user = Fabricate.create(:user,
-        uuid: uuid, login: "davydovanton", avatar_url: "https://avatars.githubusercontent.com/u/1147484?v=3",
+        login: "davydovanton", avatar_url: "https://avatars.githubusercontent.com/u/1147484?v=3",
         name: "Anton Davydov", email: "mail@davydovanton.com", bio: "Indie OSS developer")
     end
 
@@ -143,7 +141,6 @@ RSpec.describe Auth::Controllers::Sessions::Create do
       expect(action.session[:current_user].name).to eq "Anton Davydov"
       expect(action.session[:current_user].email).to eq "mail@davydovanton.com"
       expect(action.session[:current_user].bio).to eq "Indie OSS developer"
-      expect(action.session[:current_user].uuid).to eq uuid
 
       expect(action.session[:account]).to be_a Account
       expect(action.session[:account].uid).to eq uuid

--- a/spec/auth/controllers/sessions/destroy_spec.rb
+++ b/spec/auth/controllers/sessions/destroy_spec.rb
@@ -5,22 +5,24 @@ RSpec.describe Auth::Controllers::Sessions::Destroy do
   let(:params)  { { 'rack.session' => session } }
 
   context 'when session is empty' do
-    let(:session) { { current_user: nil } }
+    let(:session) { { current_user: nil, account: nil } }
 
     it 'does nothing' do
       action.call(params)
       expect(action.session[:current_user]).to be nil
+      expect(action.session[:account]).to be nil
     end
 
     it { expect(action.call(params)).to redirect_to('/') }
   end
 
   context 'when session is not empty' do
-    let(:session) { { current_user: User.new(id: 1, admin: true) } }
+    let(:session) { { current_user: User.new(id: 1, admin: true), account: Account.new(uid: '123') } }
 
     it 'deletes session value' do
       action.call(params)
       expect(action.session[:current_user]).to be nil
+      expect(action.session[:account]).to be nil
     end
 
     it { expect(action.call(params)).to redirect_to('/') }

--- a/spec/ossboard/entities/account_spec.rb
+++ b/spec/ossboard/entities/account_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe Account do
+  # place your tests here
+end

--- a/spec/ossboard/entities/account_spec.rb
+++ b/spec/ossboard/entities/account_spec.rb
@@ -1,3 +1,13 @@
 RSpec.describe Account do
-  # place your tests here
+  describe '#registred?' do
+    context 'when user is anonymous' do
+      let(:user) { Account.new }
+      it { expect(user.registred?).to be false }
+    end
+
+    context 'when user is anonymous' do
+      let(:user) { Account.new(id: 1) }
+      it { expect(user.registred?).to be true }
+    end
+  end
 end

--- a/spec/ossboard/entities/account_spec.rb
+++ b/spec/ossboard/entities/account_spec.rb
@@ -1,13 +1,54 @@
 RSpec.describe Account do
   describe '#registred?' do
     context 'when user is anonymous' do
-      let(:user) { Account.new }
-      it { expect(user.registred?).to be false }
+      let(:account) { Account.new }
+      it { expect(account.registred?).to be false }
     end
 
     context 'when user is anonymous' do
-      let(:user) { Account.new(id: 1) }
-      it { expect(user.registred?).to be true }
+      let(:account) { Account.new(id: 1) }
+      it { expect(account.registred?).to be true }
+    end
+  end
+
+  describe '#attributes' do
+    let(:account) { Account.new(id: 1, token: 'test') }
+    it { expect(account.attributes).to eq(id: 1, token: 'test') }
+  end
+
+  describe '#user=' do
+    let(:account) { Account.new }
+    let(:user) { User.new }
+
+    it 'sets user' do
+      account.user = user
+      expect(account.attributes).to eq(user: user)
+    end
+  end
+
+  describe '#user' do
+    let(:account) { Account.new(id: 1, token: 'test') }
+
+    it { expect(account.user).to eq nil }
+
+    context 'when users was set' do
+      let(:user) { User.new(login: 'davydovanton') }
+
+      it 'returns user entity' do
+        account.user = user
+        expect(account.user).to eq user
+      end
+    end
+
+    context 'wen user exist in DB' do
+      let(:user) { UserRepository.new.create(login: 'davydovanton') }
+
+      after { UserRepository.new.clear }
+
+      it 'returns user entity' do
+        account.user = user
+        expect(account.user).to eq user
+      end
     end
   end
 end

--- a/spec/ossboard/repositories/account_repository_spec.rb
+++ b/spec/ossboard/repositories/account_repository_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe AccountRepository do
+  # place your tests here
+end

--- a/spec/ossboard/repositories/account_repository_spec.rb
+++ b/spec/ossboard/repositories/account_repository_spec.rb
@@ -1,3 +1,18 @@
 RSpec.describe AccountRepository do
-  # place your tests here
+
+  describe '#find_by_uid' do
+    let(:repo) { AccountRepository.new }
+
+    context 'when user exist with uuid' do
+      before { repo.create(uid: 'test') }
+      after  { repo.clear }
+
+      it { expect(repo.find_by_uid('test')).to be_a Account }
+      it { expect(repo.find_by_uid('test').uid).to eq 'test' }
+    end
+
+    context 'when user not exist with uuid' do
+      it { expect(repo.find_by_uid('test2')).to eq nil }
+    end
+  end
 end

--- a/spec/ossboard/repositories/user_repository_spec.rb
+++ b/spec/ossboard/repositories/user_repository_spec.rb
@@ -76,19 +76,6 @@ RSpec.describe UserRepository do
     it { expect(subject.tasks.count).to eq 1 }
   end
 
-  describe '#find_by_uuid' do
-    context 'when user exist with uuid' do
-      before { Fabricate.create(:user, uuid: 'test') }
-
-      it { expect(repo.find_by_uuid('test')).to be_a User }
-      it { expect(repo.find_by_uuid('test').uuid).to eq 'test' }
-    end
-
-    context 'when user not exist with uuid' do
-      it { expect(repo.find_by_uuid('test2')).to eq nil }
-    end
-  end
-
   describe '#find_with_tasks' do
     let(:task_repo) { TaskRepository.new }
 


### PR DESCRIPTION
This changes will use Account model instead User.
Why I need this:
1. We will use Github/gitlab OAuth **(in future)**
2. We will use different GitHub auth privileges for better automatisation (we will create webhooks for user repos, etc.)

## Todo:
- [x] Create Account model
- [x] Create or use Account object in logic action
- [x] Update specs for login action
- [x] Use `session[:account]` instead `session[:current_user]` for checking auth
- [x] Update all specs for new auth logic