### PR TITLE
Add url shortener service, shorten url for twitter posts.

### DIFF
--- a/lib/ossboard/services/task_tweeter.rb
+++ b/lib/ossboard/services/task_tweeter.rb
@@ -10,7 +10,7 @@ class TaskTwitter
   private
 
   def link_to_task(task_id)
-    "http://www.ossboard.org/tasks/#{task_id}"
+    UrlShortener.call("http://www.ossboard.org/tasks/#{task_id}")
   end
 
   def text(task)

--- a/lib/ossboard/services/url_shortener.rb
+++ b/lib/ossboard/services/url_shortener.rb
@@ -1,0 +1,20 @@
+require_relative '../../post_request'
+
+class UrlShortener
+  def self.call(url)
+    new.call(url)
+  end
+
+  def call(url)
+    return url unless Hanami.env?(:production)
+    shorten_url(url)
+  end
+
+  def shorten_url(url)
+    response = PostRequest.new.call(SHORTENER_SERVICE_URL, { format: 'simple', url: url })
+    return url unless response.is_a?(Net::HTTPSuccess)
+    response.body
+  end
+
+  SHORTENER_SERVICE_URL = 'https://is.gd/create.php'.freeze
+end

--- a/lib/post_request.rb
+++ b/lib/post_request.rb
@@ -1,0 +1,16 @@
+require "net/https"
+
+class PostRequest
+  def call(url, params)
+    uri = URI.parse(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.set_form_data(params)
+    yield request if block_given?
+
+    http.request(request)
+  end
+end

--- a/spec/cassettes/isgd_shortener_fail.yml
+++ b/spec/cassettes/isgd_shortener_fail.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://is.gd/create.php
+    body:
+      encoding: US-ASCII
+      string: format=simple&url=wrong+url
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Thu, 02 Feb 2017 14:33:07 GMT
+      Content-Type:
+      - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d29dd97050c5963ecc640fe5bbc0510e61486045987; expires=Fri, 02-Feb-18
+        14:33:07 GMT; path=/; domain=.is.gd; HttpOnly
+      X-Powered-By:
+      - PHP/5.5.9-1ubuntu4.16
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 32ae5b3e0de216b2-ARN
+    body:
+      encoding: UTF-8
+      string: 'Error: Please enter a valid URL to shorten'
+    http_version: 
+  recorded_at: Thu, 02 Feb 2017 14:33:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/isgd_shortener_success.yml
+++ b/spec/cassettes/isgd_shortener_success.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://is.gd/create.php
+    body:
+      encoding: US-ASCII
+      string: format=simple&url=https%3A%2F%2Fexample.com
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Feb 2017 14:31:08 GMT
+      Content-Type:
+      - text/html
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d38de9f557394cd933af49563f0c4eaf21486045868; expires=Fri, 02-Feb-18
+        14:31:08 GMT; path=/; domain=.is.gd; HttpOnly
+      X-Powered-By:
+      - PHP/5.5.9-1ubuntu4.16
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 32ae58546fa016e2-ARN
+    body:
+      encoding: ASCII-8BIT
+      string: https://is.gd/jGamH3
+    http_version: 
+  recorded_at: Thu, 02 Feb 2017 14:31:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/ossboard/services/task_twitter_spec.rb
+++ b/spec/ossboard/services/task_twitter_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe TaskTwitter do
         expected_text = "#{task.title} #ossboard http://www.ossboard.org/tasks/#{task.id}"
         expect(subject).to eq expected_text
       end
+
+      it 'shortens the url' do
+        expect(UrlShortener).to receive(:call).with("http://www.ossboard.org/tasks/#{task.id}")
+        subject
+      end
     end
 
     context 'when title long' do

--- a/spec/ossboard/services/url_shortener_spec.rb
+++ b/spec/ossboard/services/url_shortener_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe UrlShortener do
+  subject { UrlShortener.new }
+
+  describe '#shorten_url' do
+    it 'shortens valid url' do
+      VCR.use_cassette("isgd_shortener_success") do
+        url = subject.shorten_url('https://example.com')
+        expect(url).to eq 'https://is.gd/jGamH3'
+      end
+    end
+
+    it "doesn't shorten invalid url" do
+      VCR.use_cassette("isgd_shortener_fail") do
+        url = subject.shorten_url('wrong url')
+        expect(url).to eq 'wrong url'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relates to "Twitter messages: use shortener for links #67"

- Adds `UrlShortener` service
- Adds `PostRequest` class, which performs post requests
- `TaskTwitter` calls `UrlShortener` for a task url.