### PR TITLE
Fix task title paddings

### DIFF
--- a/apps/web/assets/stylesheets/_tasks.scss
+++ b/apps/web/assets/stylesheets/_tasks.scss
@@ -151,8 +151,10 @@
       font-size: 22px;
       color: #214CFD;
       letter-spacing: 0;
-      margin-left: -8px;
 
+      a {
+        padding: 0;
+      }
       a:link,
       a:active,
       a:visited {

--- a/apps/web/assets/stylesheets/_user.scss
+++ b/apps/web/assets/stylesheets/_user.scss
@@ -122,6 +122,9 @@
 
       .task-item__title {
         width: 60%;
+        a {
+          padding: 0;
+        }
         span {
           margin: 0 10px;
         }


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/1381503/22702630/69758e04-ed72-11e6-883e-ef4986788053.png)

After:
![image](https://cloud.githubusercontent.com/assets/1381503/22702678/850788e8-ed72-11e6-95f3-e5201c77920a.png)

Also, fixed task titles on user page.