### PR TITLE
Parse links in task description

### DIFF
--- a/config/initializers/markdown.rb
+++ b/config/initializers/markdown.rb
@@ -2,8 +2,13 @@ require 'kramdown'
 require 'rouge'
 
 class Markdown
+  LINK_REGEXP = %r((?<![=["|']|><a-z0-9_\.])(?<!http:\/\/)((http[s]?\:\/\/)?([a-z0-9\.]+\.[a-z]{2,5}(\/[\?=&a-z0-9_\.\/]+)?)))
+
   def self.parse(text)
-    ::Kramdown::Document.new(text, input: 'GFM',
-        coderay_csscoderay_css: :class, syntax_highlighter: :rouge).to_html
+    html = ::Kramdown::Document.new(text,
+                                    input: 'GFM',
+                                    coderay_csscoderay_css: :class,
+                                    syntax_highlighter: :rouge).to_html
+    html.gsub(LINK_REGEXP, '<a href="\1">\1</a>')
   end
 end

--- a/spec/api/controllers/md_preview/create_spec.rb
+++ b/spec/api/controllers/md_preview/create_spec.rb
@@ -20,4 +20,34 @@ RSpec.describe Api::Controllers::MdPreview::Create do
     it { expect(action.call(params)).to be_success }
     it { expect(action.call(params).last).to eq ['{"text":"<p>This is <em>bongos</em>, indeed.</p>\n"}'] }
   end
+
+  context 'when md text has link without protocol' do
+    let(:params) { { md_text: 'Bingo-bongo! test google.com' } }
+    it { expect(action.call(params)).to be_success }
+    it { expect(action.call(params).last).to eq ['{"text":"<p>Bingo-bongo! test <a href=\"google.com\">google.com</a></p>\n"}'] }
+  end
+
+  context 'when md text has link with protocol' do
+    let(:params) { { md_text: 'Bingo-bongo! test http://google.com ' } }
+    it { expect(action.call(params)).to be_success }
+    it { expect(action.call(params).last).to eq ['{"text":"<p>Bingo-bongo! test <a href=\"http://google.com\">http://google.com</a></p>\n"}'] }
+  end
+
+  context 'when md text has link with params' do
+    let(:params) { { md_text: 'Bingo-bongo! test http://google.com/?q=12354 ' } }
+    it { expect(action.call(params)).to be_success }
+    it { expect(action.call(params).last).to eq ['{"text":"<p>Bingo-bongo! test <a href=\"http://google.com/?q=12354\">http://google.com/?q=12354</a></p>\n"}'] }
+  end
+
+  context 'when md text has md link with brackets' do
+    let(:params) { { md_text: 'Bingo-bongo! test <http://google.com> ' } }
+    it { expect(action.call(params)).to be_success }
+    it { expect(action.call(params).last).to eq ['{"text":"<p>Bingo-bongo! test <a href=\"http://google.com\">http://google.com</a></p>\n"}'] }
+  end
+
+  context 'when md text has md link' do
+    let(:params) { { md_text: 'Bingo-bongo! test [http://google.com](http://google.com) ' } }
+    it { expect(action.call(params)).to be_success }
+    it { expect(action.call(params).last).to eq ['{"text":"<p>Bingo-bongo! test <a href=\"http://google.com\">http://google.com</a></p>\n"}'] }
+  end
 end


### PR DESCRIPTION
This closes ossboard-org/ossboard#95
I added opportunity to parse undecorated links.
I mean:
md interprets  `[link](google.com)`  as `<a href="google.com">link</a>`, `<google.com>` as `<a href="google.com">google.com</a>`, I left these links untouched.

And just written somewhere in text
`To read more about it you can visit github.com/ossboard/ossboard`
 would produce 
`To read more about it you can visit <a href="github.com/ossboard/ossboard">github.com/ossboard/ossboard</a>`.

I have some proposals - we can check link status. If link is alive - we can generate anchor wrapper and detect necessary protocol.