### PR TITLE
Remove spec files from coverage report

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,9 @@ SimpleCov.formatters = [
   SimpleCov::Formatter::JSONFormatter
 ]
 
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec/"
+end
 
 # This line needed to fix the error
 # NoMethodError: undefined method `user_id' for <Rake::Task  => []>:Rake::Task


### PR DESCRIPTION
Now coverage report 94%, is not true. The report includes spec files. If we add filter, coverage reduced to 91%