### PR TITLE
Use newrelic only in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /coverage
 /log
 /.env.local
+npm-debug.log

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'dry-monads'
 gem 'sidekiq'
 gem 'sidekiq-scheduler'
 
-gem 'newrelic-hanami', github: 'artemeff/newrelic-hanami'
 gem 'secure_headers'
 
 gem 'twitter'
@@ -73,5 +72,5 @@ group :test do
 end
 
 group :production do
-  # gem 'puma'
+  gem 'newrelic-hanami', github: 'artemeff/newrelic-hanami'
 end

--- a/config.ru
+++ b/config.ru
@@ -1,12 +1,14 @@
 require './config/environment'
 require 'omniauth'
-require 'newrelic_rpm'
-require 'newrelic-hanami'
 
 # TODO: call `letsencrypt_heroku` when we switch to Hobby heroku plan
 use LetsencryptRack::Middleware
 
-NewRelic::Agent.manual_start
+if Hanami.env?(:production)
+  require 'newrelic_rpm'
+  require 'newrelic-hanami'
+  NewRelic::Agent.manual_start
+end
 
 use SecureHeaders::Middleware
 use Rack::Session::Cookie, secret: ENV['SESSIONS_SECRET']


### PR DESCRIPTION
I think we should use newrelic only in `production` mode, not in `development` and `test`.
@davydovanton WDYT?