### PR TITLE
Use valid lang list in select

### DIFF
--- a/apps/admin/views/application_layout.rb
+++ b/apps/admin/views/application_layout.rb
@@ -3,10 +3,6 @@ module Admin
     class ApplicationLayout
       include Admin::Layout
 
-      def langs_list
-        LANGUAGES_HASH
-      end
-
       def complexity_options_list
         COMPLEXITY_OPTIONS_HASH
       end
@@ -16,23 +12,6 @@ module Admin
       end
 
     private
-
-      LANGUAGES_HASH = {
-        'language' => 'unknown',
-        'ruby'     => 'ruby',
-        'js'       => 'js',
-        'java'     => 'java',
-        'Python'   => 'Python',
-        'go'       => 'go',
-        'haskell'  => 'haskell',
-        'lua'      => 'lua',
-        'scala'    => 'scala',
-        'elixir'   => 'elixir',
-        'rust'     => 'rust',
-        'clojure'  => 'clojure',
-        'php'      => 'php',
-        'crystal'  => 'crystal'
-      }.freeze
 
       COMPLEXITY_OPTIONS_HASH = {
         'Easy' => 'easy',

--- a/apps/admin/views/tasks/edit.rb
+++ b/apps/admin/views/tasks/edit.rb
@@ -46,7 +46,7 @@ module Admin::Views::Tasks
           end
 
           div class: 'input task-form__field' do
-            select :lang, langs_list
+            select :lang, Task::VALID_LANGUAGES
           end
 
           div class: 'input task-form__field pure-control-group' do

--- a/apps/web/views/application_layout.rb
+++ b/apps/web/views/application_layout.rb
@@ -7,10 +7,6 @@ module Web
         link_to 'admin app', '/admin', class: 'header-menu-item__link'
       end
 
-      def langs_list
-        LANGUAGES_HASH
-      end
-
       def complexity_options_list
         COMPLEXITY_OPTIONS_HASH
       end
@@ -24,22 +20,6 @@ module Web
       end
 
     private
-
-      LANGUAGES_HASH = {
-        'language' => 'unknown',
-        'ruby'     => 'ruby',
-        'js'       => 'javascript',
-        'java'     => 'java',
-        'python'   => 'python',
-        'go'       => 'go',
-        'haskell'  => 'haskell',
-        'lua'      => 'lua',
-        'scala'    => 'scala',
-        'elixir'   => 'elixir',
-        'rust'     => 'rust',
-        'clojure'  => 'clojure',
-        'php'      => 'php'
-      }.freeze
 
       COMPLEXITY_OPTIONS_HASH = {
         'Easy' => 'easy',

--- a/apps/web/views/tasks/edit.rb
+++ b/apps/web/views/tasks/edit.rb
@@ -26,7 +26,7 @@ module Web::Views::Tasks
         end
 
         div class: 'input' do
-          select :lang, langs_list
+          select :lang, Task::VALID_LANGUAGES
         end
 
         if current_user.registred?

--- a/apps/web/views/tasks/new.rb
+++ b/apps/web/views/tasks/new.rb
@@ -45,7 +45,7 @@ module Web::Views::Tasks
 
           div class: 'input' do
             label(:lang) { text('Task language') }
-            select :lang, langs_list
+            select :lang, Task::VALID_LANGUAGES
           end
         end
 


### PR DESCRIPTION
In this PR https://github.com/ossboard-org/ossboard/pull/105 we add crystal lang, but the option does not show in new task page. 

I think we should define langs in single place.