### PR TITLE
Run webpack before specs to get tests passed

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,9 @@ RSpec.configure do |config|
   # avoid conflicts with Capybara, see https://github.com/teamcapybara/capybara/issues/1396
   config.include RspecEvery
 
+  config.before(:suite) do
+    `#{__dir__}/../node_modules/.bin/webpack`
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
Ossboard build fails for a while with

` No such file or directory @ rb_sysopen - /home/travis/build/ossboard-org/ossboard/public/webpack_manifest.json`

Is the way I start webpack OK?