### PR TITLE
Fix deprecations & specs

### DIFF
--- a/apps/admin/views/tasks/index.rb
+++ b/apps/admin/views/tasks/index.rb
@@ -3,7 +3,7 @@ module Admin::Views::Tasks
     include Admin::View
 
     def tasks
-      TaskRepository.new.tasks.order{ id.desc }.as(Task).to_a
+      TaskRepository.new.tasks.order{ id.desc }.map_to(Task).to_a
     end
 
     def repository_name(task)

--- a/apps/admin/views/users/index.rb
+++ b/apps/admin/views/users/index.rb
@@ -3,7 +3,7 @@ module Admin::Views::Users
     include Admin::View
 
     def users
-      UserRepository.new.users.order{ id.desc }.as(User).to_a
+      UserRepository.new.users.order{ id.desc }.map_to(User).to_a
     end
 
     def banned_users

--- a/lib/ossboard/repositories/task_repository.rb
+++ b/lib/ossboard/repositories/task_repository.rb
@@ -39,7 +39,7 @@ class TaskRepository < Hanami::Repository
   private
 
   def all_from_date_request(from, status = nil)
-    request = tasks.where("created_at > '#{from}'").where("created_at < '#{Time.now}'")
+    request = tasks.where { (created_at > from) & (created_at < Time.now) }
     request = request.where(status: status) if status
     request
   end

--- a/lib/ossboard/repositories/user_repository.rb
+++ b/lib/ossboard/repositories/user_repository.rb
@@ -42,6 +42,6 @@ class UserRepository < Hanami::Repository
   private
 
   def all_from_date_request(from)
-    users.where("created_at > '#{from}'").where("created_at < '#{Time.now}'")
+    users.where { (created_at > from) & (created_at < Time.now) }
   end
 end


### PR DESCRIPTION
Fix deprecations: `as` -> `map_to` & where syntax.

During testing, I saw that task repository specs fail sometime:
```
  1) TaskRepository#not_approved returns not approved tasks
     Failure/Error: expect(result.size).to eq 1
     
       expected: 1
            got: 26
```
See https://travis-ci.org/ossboard-org/ossboard/builds/279866279 for example.

It happens when `#all_from_date` block runs before `#not_approved`. `#all_from_date` uses `before(:all)`, so code inside it runs outside of transaction, which leads tasks to not rollback.