### PR TITLE
Autolinker: prevent from messing with images and marked links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'letsencrypt_heroku', require: false
 # markdown
 gem 'kramdown', '1.13.1'
 gem 'rouge', '1.11.1'
+gem 'rinku'
 
 gem 'pg'
 gem 'redis', '~>3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ GEM
     rake (12.0.0)
     redis (3.3.3)
     relative_time (1.0.0)
+    rinku (2.0.3)
     rom (3.3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.3)
@@ -435,6 +436,7 @@ DEPENDENCIES
   rake
   redis (~> 3.2)
   relative_time
+  rinku
   rouge (= 1.11.1)
   rspec
   rspec-hanami!

--- a/lib/ossboard/core/markdown.rb
+++ b/lib/ossboard/core/markdown.rb
@@ -1,9 +1,10 @@
 require 'kramdown'
 require 'rouge'
+require 'rinku'
+
 
 module Core
   class Markdown
-    LINK_REGEXP = %r((?<![=["|']|><a-z0-9_\.])(?<!http:\/\/)((http[s]?\:\/\/)?([a-z0-9\.]+\.[a-z]{2,5}(\/[\?=&a-z0-9_\.\/]+)?)))
     CHECKBOX_REGEXP_CHECKED = %r(\K\[(x|X)\]\s?(.*)<)
     CHECKBOX_REGEXP_UNCHECKED = %r(\K\[ \]\s?(.*)<)
 
@@ -12,9 +13,10 @@ module Core
                                       input: 'GFM',
                                       coderay_csscoderay_css: :class,
                                       syntax_highlighter: :rouge).to_html
-      html.gsub(CHECKBOX_REGEXP_CHECKED, %(<input type="checkbox" checked disabled><label>\\2</label><))
+      html = html.gsub(CHECKBOX_REGEXP_CHECKED, %(<input type="checkbox" checked disabled><label>\\2</label><))
         .gsub(CHECKBOX_REGEXP_UNCHECKED, %(<input type="checkbox" disabled><label>\\1</label><))
-        .gsub(LINK_REGEXP, '<a href="\1">\1</a>')
+
+      Rinku.auto_link(html)
     end
   end
 end

--- a/spec/api/controllers/md_preview/create_spec.rb
+++ b/spec/api/controllers/md_preview/create_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Api::Controllers::MdPreview::Create do
   end
 
   context 'when md text has link without protocol' do
-    let(:params) { { md_text: 'Bingo-bongo! test google.com' } }
+    let(:params) { { md_text: 'Bingo-bongo! test http://google.com' } }
     it { expect(action.call(params)).to be_success }
-    it { expect(action.call(params).last).to eq ['{"text":"<p>Bingo-bongo! test <a href=\"google.com\">google.com</a></p>\n"}'] }
+    it { expect(action.call(params).last).to eq ['{"text":"<p>Bingo-bongo! test <a href=\"http://google.com\">http://google.com</a></p>\n"}'] }
   end
 
   context 'when md text has link with protocol' do

--- a/spec/ossboard/core/markdown_spec.rb
+++ b/spec/ossboard/core/markdown_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe Core::Markdown do
+  let(:markdown){ Core::Markdown.new() }
+  let(:body){ '*test*' }
+  subject { markdown.parse(body) }
+
+  it { expect(subject).to eq("<p><em>test</em></p>\n") }
+
+  context 'image' do
+    let(:body){ '![violin](https://github.com)' }
+    it { expect(subject).to eq("<p><img src=\"https://github.com\" alt=\"violin\" /></p>\n") }
+  end
+
+  context 'links' do
+    let(:body){ '[google.com](https://google.com)' }
+    it { expect(subject).to eq(%{<p><a href="https://google.com">google.com</a></p>\n}) }
+  end
+
+  context 'link from text' do
+    let(:body){ 'https://google.com' }
+    it { expect(subject).to eq(%{<p><a href="https://google.com">https://google.com</a></p>\n}) }
+  end
+end


### PR DESCRIPTION
When task is imported from github, parser breaks the image link. We get stuff like this
![screenshot from 2017-10-08 00-42-34](https://user-images.githubusercontent.com/2440125/31312015-b68f375e-abc1-11e7-988a-57fe0cea0a73.png)

I would expect it just inserts the image.

The problem was in auto-linking regexp.
I haven't found reliable and non-destructive way to auto-link plane text without parsing. [Rinku](https://github.com/vmg/rinku) can be used for that purpose. Or we can just disable the autolink at all.

Also rinku doesn't parse links without protocol, but I believe it's good thing.

P.s. random fact: there is method `URI.regexp` that generates regexp to match any url