### PR TITLE
Add docker for local development

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM ruby:2.4.1-slim
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 68576280 \
+  && echo 'deb http://deb.nodesource.com/node_8.x trusty main' > /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update -qq \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    nodejs \
+    locales \
+    git-core \
+    libpq-dev \
+    libfontconfig \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && truncate -s 0 /var/log/*log
+
+WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+HANAMI_ENV ?= development
+RUN := run --rm
+DOCKER_COMPOSE_RUN := docker-compose $(RUN)
+
+default: test
+
+test:
+	bundle exec rspec
+
+app-web:
+	${DOCKER_COMPOSE_RUN} --service-ports web
+
+app-job:
+	${DOCKER_COMPOSE_RUN} job
+
+app-bash:
+	${DOCKER_COMPOSE_RUN} -e "HANAMI_ENV=${HANAMI_ENV}" app bash
+
+app-down:
+	docker-compose down
+
+app-build:
+	docker-compose build app

--- a/apps/web/assets/javascripts/main.js
+++ b/apps/web/assets/javascripts/main.js
@@ -44,54 +44,56 @@ Vue.component('modal', {
   template: '#modal-template',
 })
 
-new Vue({
-  el: '#import-modal',
-  data: {
-    showModal: false,
-    hasError: false,
-    errorMessage: '',
-    exportingIssue: false,
-    xhr: new XMLHttpRequest()
-  },
-  methods: {
-    exportIssue: function () {
-      var url = '/api/issue?issue_url=' + document.getElementById('issueUrl').value
-      var self = this
-      var default_complexity = 'easy'
-      this.exportingIssue = true
+if (document.getElementById("import-modal")) {
+  new Vue({
+    el: '#import-modal',
+    data: {
+      showModal: false,
+      hasError: false,
+      errorMessage: '',
+      exportingIssue: false,
+      xhr: new XMLHttpRequest()
+    },
+    methods: {
+      exportIssue: function () {
+        var url = '/api/issue?issue_url=' + document.getElementById('issueUrl').value
+        var self = this
+        var default_complexity = 'easy'
+        this.exportingIssue = true
 
-      this.xhr.open('GET', url, true);
-      this.xhr.setRequestHeader('Content-type', 'application/json');
-      this.xhr.setRequestHeader('Accept', 'application/json');
-      this.xhr.onload = function() {
-        var data = JSON.parse(self.xhr.response)
+        this.xhr.open('GET', url, true);
+        this.xhr.setRequestHeader('Content-type', 'application/json');
+        this.xhr.setRequestHeader('Accept', 'application/json');
+        this.xhr.onload = function() {
+          var data = JSON.parse(self.xhr.response)
 
-        if (self.xhr.status == 200) {
-          document.getElementById('task-title').value = data.title
-          document.getElementById('task-repository-name').value = data.repository_name
-          document.getElementById('task-issue-url').value = data.html_url
-          document.getElementById('task-md-body').value = data.body
-          document.getElementById('task-lang').value = data.lang
-          document.getElementById('task-complexity').value = data.complexity ? data.complexity : default_complexity
-          self.showModal = false
-        } else {
-          self.hasError = true;
-          self.errorMessage = 'Error: ' + data.error;
-        }
+          if (self.xhr.status == 200) {
+            document.getElementById('task-title').value = data.title
+            document.getElementById('task-repository-name').value = data.repository_name
+            document.getElementById('task-issue-url').value = data.html_url
+            document.getElementById('task-md-body').value = data.body
+            document.getElementById('task-lang').value = data.lang
+            document.getElementById('task-complexity').value = data.complexity ? data.complexity : default_complexity
+            self.showModal = false
+          } else {
+            self.hasError = true;
+            self.errorMessage = 'Error: ' + data.error;
+          }
 
-        self.exportingIssue = false
-      };
-      this.xhr.send();
-    }
-  },
-  created: function () {
-    document.addEventListener("keydown", (e) => {
-      if (this.showModal && e.keyCode == 27) {
-        this.showModal = false;
+          self.exportingIssue = false
+        };
+        this.xhr.send();
       }
-    });
-  }
-})
+    },
+    created: function () {
+      document.addEventListener("keydown", (e) => {
+        if (this.showModal && e.keyCode == 27) {
+          this.showModal = false;
+        }
+      });
+    }
+  })
+}
 
 var agreementChackbox = document.getElementById("agreement-checkbox"),
     submitButton = document.getElementById("new-task-submit"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3'
+services:
+  db:
+    image: 'postgres:9.6'
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:alpine
+
+  app: &app
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    image: ossboard
+    command: bash
+    volumes:
+      - .:/app
+      - bundler-data:/usr/local/bundle/:cached
+      - bin-data:/usr/local/bin/:cached
+    environment:
+      - HANAMI_ENV=${HANAMI_ENV:-development}
+    depends_on:
+      - db
+      - redis
+
+  web:
+    <<: *app
+    command: bundle exec hanami server --host '0.0.0.0'
+    environment:
+      - WEB_CONCURRENCY=${WEB_CONCURRENCY:-0}
+      - WEBPACK_DEV_SERVER_PORT=3020
+      - WEBPACK_DEV_SERVER_HOST=0.0.0.0
+    ports:
+      - "2300:2300"
+      - "3020:3020"
+
+  job:
+    <<: *app
+    command: bundle exec sidekiq -C config/sidekiq.yml
+
+volumes:
+  bundler-data:
+  bin-data:
+  pg-data:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "live-server": "^1.1.0",
     "node-sass": "^3.13.0",
+    "phantomjs": "^2.1.7",
     "sass-loader": "^4.0.2",
     "script-loader": "^0.7.0",
     "stats-webpack-plugin": "*",

--- a/spec/features_helper.rb
+++ b/spec/features_helper.rb
@@ -9,6 +9,7 @@ require 'capybara/poltergeist'
 
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, js_errors: false)
+  Capybara::Poltergeist::Driver.new(app, phantomjs: (Hanami.root + 'node_modules/.bin/phantomjs').to_s)
 end
 
 Capybara.javascript_driver = :poltergeist
@@ -34,4 +35,4 @@ RSpec.configure do |config|
   config.around(:each, :js) { |ex| ex.run_with_retry retry: 3 }
 end
 
-`cd #{Hanami.root} && webpack`
+`cd #{Hanami.root} && ./node_modules/.bin/webpack`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,7 @@ var config = {
 if (process.env.INBUILT_WEBPACK_DEV_SERVER === 'true') {
   config.devServer = {
     port: devServerPort,
+    host: devServerHost,
     headers: { "Access-Control-Allow-Origin": "*" }
   };
   config.output.publicPath = "//" + devServerHost + ":" + devServerPort + "/";


### PR DESCRIPTION
1. Add docker + docker compose for local development. All commands encapsulated in Makefile. For example:
`make app-web` - Starts web application
`make app-job` - Starts sidekiq worker
`make app-bash HANAMI_ENV=test` - starts bash session in docker with tests environment

Example for configure db `DATABASE_URL="postgres://postgres@db/ossboard_development"`

2. Fixed vue warnings when `import-modal` element not on the page